### PR TITLE
Fix 500 for crawlers: locale middleware crashes without Accept-Language

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -33,11 +33,31 @@ const DEFAULT_LOCALE: (typeof SUPPORTED)[number] = 'en';
  * console.log(locale); // 'en' or 'es'
  */
 function getPreferredLocale(request: NextRequest): (typeof SUPPORTED)[number] {
-  const negotiator = new Negotiator({
-    headers: Object.fromEntries(request.headers.entries()),
-  });
-  const languages = negotiator.languages();
-  return localeMatch(languages, SUPPORTED, DEFAULT_LOCALE) as (typeof SUPPORTED)[number];
+  try {
+    const negotiator = new Negotiator({
+      headers: Object.fromEntries(request.headers.entries()),
+    });
+
+    // Negotiator returns ['*'] when the request carries no Accept-Language
+    // header at all - which is the case for crawlers such as Googlebot and
+    // facebookexternalhit, and for uptime monitors. '*' is not a structurally
+    // valid BCP 47 language tag, so passing it to the locale matcher throws
+    // `RangeError: Incorrect locale information provided` and takes down every
+    // route with a 500. Drop wildcards and anything malformed before matching.
+    const languages = negotiator
+      .languages()
+      .filter((lang) => typeof lang === 'string' && lang !== '*' && /^[a-zA-Z]{2,8}(-[a-zA-Z0-9]{1,8})*$/.test(lang));
+
+    if (languages.length === 0) {
+      return DEFAULT_LOCALE;
+    }
+
+    return localeMatch(languages, SUPPORTED, DEFAULT_LOCALE) as (typeof SUPPORTED)[number];
+  } catch {
+    // Locale negotiation must never be able to break the site. Any unexpected
+    // input falls back to the default locale.
+    return DEFAULT_LOCALE;
+  }
 }
 
 /**


### PR DESCRIPTION
**Problem**

Every request arriving without an `Accept-Language` header returned **HTTP 500** with `RangeError: Incorrect locale information provided`.

Browsers always send the header, so humans saw the site normally. Crawlers never do, so **Googlebot, facebookexternalhit and uptime monitors got a 500 on every route** - silently de-indexing the site and breaking Meta link previews.

**Cause**

`negotiator.languages()` returns `['*']` when the header is absent. `'*'` is not a structurally valid BCP 47 tag, so `@formatjs/intl-localematcher`'s `match()` throws. Not a deploy regression - the last production deploy was 2 Sept 2025 and shipped clean.

**Fix**

Filter wildcard and malformed tags before matching, fall back to `DEFAULT_LOCALE` when nothing valid remains, and wrap negotiation in try/catch so locale handling can never take the site down.

**Verification**

| Accept-Language | before | after |
|---|---|---|
| (none) | RangeError -> 500 | `en` |
| `*` | RangeError -> 500 | `en` |
| `en-US,en;q=0.9` | `en` | `en` |
| `es-ES,es;q=0.9` | `es` | `es` |
| `zz` | `en` | `en` |

Spanish detection unchanged.
