### PR TITLE
Add robots.txt and sitemap.xml routes

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from 'next';
+
+const BASE_URL = 'https://www.gracehavenmedical.com';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+      },
+    ],
+    sitemap: `${BASE_URL}/sitemap.xml`,
+    host: BASE_URL,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,33 @@
+import type { MetadataRoute } from 'next';
+
+const BASE_URL = 'https://www.gracehavenmedical.com';
+
+// Public routes served from src/app/(routes). Keep in sync when pages are added or removed.
+const ROUTES: { path: string; priority: number }[] = [
+  { path: '/', priority: 1.0 },
+  { path: '/about-us', priority: 0.8 },
+  { path: '/contact-us', priority: 0.9 },
+  { path: '/memberships', priority: 0.8 },
+  { path: '/weight-loss', priority: 0.9 },
+  { path: '/weight-loss-and-anti-aging-injections', priority: 0.8 },
+  { path: '/mens-health', priority: 0.8 },
+  { path: '/lab-testing', priority: 0.7 },
+  { path: '/iv-therapy', priority: 0.7 },
+  { path: '/3d-body-composition', priority: 0.6 },
+  { path: '/infrared-therapy', priority: 0.6 },
+  { path: '/ionized-foot-detox', priority: 0.6 },
+  { path: '/magnet-therapy', priority: 0.6 },
+  { path: '/crunchi-skincare', priority: 0.5 },
+  { path: '/patchaid-vitamins', priority: 0.5 },
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+
+  return ROUTES.map(({ path, priority }) => ({
+    url: `${BASE_URL}${path}`,
+    lastModified,
+    changeFrequency: 'weekly' as const,
+    priority,
+  }));
+}


### PR DESCRIPTION
Both robots.txt and sitemap.xml currently return 404. Without them Google re-crawls slowly and keeps serving cached page text - including the old practice address (23080 Tabak Ln), which is what search snippets and voice assistants still read, even though every live page already shows 5132 Land O Lakes Blvd Ste 101.

Adds the two standard Next.js App Router metadata routes:
- src/app/robots.ts - allows all crawlers, declares the sitemap
- src/app/sitemap.ts - lists the 15 public routes with priorities

No page content or runtime behaviour changes. After merge and deploy, submit a re-index request in Search Console.